### PR TITLE
Add documentation strings for API

### DIFF
--- a/project/src/Behaviors/GSTArrive.gd
+++ b/project/src/Behaviors/GSTArrive.gd
@@ -4,12 +4,17 @@ extends GSTSteeringBehavior
 # The calculation will attempt to arrive with zero remaining velocity.
 
 
+# The target whose location the agent will be steered to arrive at
 var target: GSTAgentLocation
+# The distance from the target for the agent to be considered successfully arrived
 var arrival_tolerance: float
+# The distance from the target for the agent to begin slowing down
 var deceleration_radius: float
+# A constant that represents the time it takes to change acceleration
 var time_to_reach := 0.1
 
 
+# Initializes the behavior
 func _init(agent: GSTSteeringAgent, target: GSTAgentLocation).(agent) -> void:
 	self.target = target
 

--- a/project/src/Behaviors/GSTAvoidCollisions.gd
+++ b/project/src/Behaviors/GSTAvoidCollisions.gd
@@ -1,6 +1,6 @@
 class_name GSTAvoidCollisions
 extends GSTGroupBehavior
-# Behavior that steers the agent to avoid obstacles lying in its path as approximated by a sphere.
+# Behavior that steers the agent to avoid obstacles lying in its path as approximated by spheres.
 
 
 var first_neighbor: GSTSteeringAgent
@@ -11,6 +11,7 @@ var first_relative_position: Vector3
 var first_relative_velocity: Vector3
 
 
+# Intializes the behavior
 func _init(agent: GSTSteeringAgent, proximity: GSTProximity).(agent, proximity) -> void:
 	pass
 

--- a/project/src/Behaviors/GSTBlend.gd
+++ b/project/src/Behaviors/GSTBlend.gd
@@ -1,11 +1,11 @@
 class_name GSTBlend
 extends GSTSteeringBehavior
 # Blends multiple steering behaviors into one, and returns acceleration combining all of them.
-
-# # Each behavior is associated with a weight - a modifier by which the result will be multiplied by,
+# 
+# Each behavior is associated with a weight - a modifier by which the result will be multiplied by,
 # then added to a total acceleration.
-
-# # Each behavior is stored internally as a `Dictionary` with a `behavior` key with a value of type
+# 
+# Each behavior is stored internally as a `Dictionary` with a `behavior` key with a value of type
 # `GSTSteeringBehavior` and a `weight` key with a value of type float.
 
 
@@ -13,15 +13,18 @@ var _behaviors := []
 var _accel := GSTTargetAcceleration.new()
 
 
+# Initializes the behavior
 func _init(agent: GSTSteeringAgent).(agent) -> void:
 	pass
 
 
+# Adds a behavior to the next index and gives it a `weight` by which its results will be multiplied
 func add(behavior: GSTSteeringBehavior, weight: float) -> void:
 	behavior.agent = agent
 	_behaviors.append({behavior = behavior, weight = weight})
 
 
+# Returns the behavior at the specified `index`. Returns an empty `Dictionary` if none was found.
 func get_behavior_at(index: int) -> Dictionary:
 	if _behaviors.size() > index:
 		return _behaviors[index]

--- a/project/src/Behaviors/GSTCohesion.gd
+++ b/project/src/Behaviors/GSTCohesion.gd
@@ -1,12 +1,13 @@
 class_name GSTCohesion
 extends GSTGroupBehavior
 # Group behavior that produces linear acceleration that attempts to move the agent towards the
-# center of mass of the agents in the area defined by the defined Proximity.
+# center of mass of the agents in the area defined by the Proximity.
 
 
 var center_of_mass: Vector3
 
 
+# Initializes the behavior
 func _init(agent: GSTSteeringAgent, proximity: GSTProximity).(agent, proximity) -> void:
 	pass
 

--- a/project/src/Behaviors/GSTEvade.gd
+++ b/project/src/Behaviors/GSTEvade.gd
@@ -2,9 +2,8 @@ class_name GSTEvade
 extends GSTPursue
 # Calculates acceleration to take an agent away from where a target agent will be.
 
-# # The `predict_time_max` variable represents how far ahead to calculate the intersection point.
 
-
+# Initializes the behavior
 func _init(
 		agent: GSTSteeringAgent,
 		target: GSTSteeringAgent,

--- a/project/src/Behaviors/GSTFace.gd
+++ b/project/src/Behaviors/GSTFace.gd
@@ -4,6 +4,7 @@ extends GSTMatchOrientation
 # The acceleration will attempt to arrive with zero remaining angular velocity.
 
 
+# Initializes the behavior
 func _init(agent: GSTSteeringAgent, target: GSTAgentLocation).(agent, target) -> void:
 	pass
 

--- a/project/src/Behaviors/GSTFace.gd
+++ b/project/src/Behaviors/GSTFace.gd
@@ -16,7 +16,7 @@ func _face(acceleration: GSTTargetAcceleration, target_position: Vector3) -> GST
 		acceleration.set_zero()
 		return acceleration
 	else:
-		var orientation = atan2(to_target.x, -to_target.y)
+		var orientation = GSTUtils.vector_to_angle(to_target)
 		return _match_orientation(acceleration, orientation)
 
 

--- a/project/src/Behaviors/GSTFlee.gd
+++ b/project/src/Behaviors/GSTFlee.gd
@@ -3,6 +3,7 @@ extends GSTSeek
 # Calculates acceleration to take an agent directly away from a target agent.
 
 
+# Initializes the behavior
 func _init(agent: GSTSteeringAgent, target: GSTAgentLocation).(agent, target) -> void:
 	pass
 

--- a/project/src/Behaviors/GSTFollowPath.gd
+++ b/project/src/Behaviors/GSTFollowPath.gd
@@ -3,13 +3,19 @@ extends GSTArrive
 # Produces a linear acceleration that moves the agent along the specified path.
 
 
+# The path to follow and travel along
 var path: GSTPath
+# The distance along the path to generate the next target position.
 var path_offset := 0.0
 
+# Whether to use `GSTArrive` behavior on an open path.
 var arrive_enabled := true
+# The amount of time in the future to predict the owning agent's position along the path. Setting
+# it to 0 will force non-predictive path following.
 var prediction_time := 0.0
 
 
+# Initializes the behavior
 func _init(
 		agent: GSTSteeringAgent, 
 		path: GSTPath, 

--- a/project/src/Behaviors/GSTFollowPath.gd
+++ b/project/src/Behaviors/GSTFollowPath.gd
@@ -6,8 +6,6 @@ extends GSTArrive
 var path: GSTPath
 var path_offset := 0.0
 
-var path_param := {segment_index = 0, distance = 0}
-
 var arrive_enabled := true
 var prediction_time := 0.0
 
@@ -27,10 +25,10 @@ func _calculate_steering(acceleration: GSTTargetAcceleration) -> GSTTargetAccele
 			agent.position if prediction_time == 0
 			else agent.position + (agent.linear_velocity * prediction_time))
 	
-	var distance := path.calculate_distance(location, path_param)
+	var distance := path.calculate_distance(location)
 	var target_distance := distance + path_offset
 	
-	var target_position := path.calculate_target_position(path_param, target_distance)
+	var target_position := path.calculate_target_position(target_distance)
 	
 	if arrive_enabled and path.open:
 		if path_offset >= 0:

--- a/project/src/Behaviors/GSTLookWhereYouGo.gd
+++ b/project/src/Behaviors/GSTLookWhereYouGo.gd
@@ -3,6 +3,7 @@ extends GSTMatchOrientation
 # Calculates an angular acceleration to match an agent's orientation to its direction of travel.
 
 
+# Initializes the behavior
 func _init(agent: GSTSteeringAgent).(agent, null) -> void:
 	pass
 

--- a/project/src/Behaviors/GSTLookWhereYouGo.gd
+++ b/project/src/Behaviors/GSTLookWhereYouGo.gd
@@ -12,5 +12,5 @@ func _calculate_steering(accel: GSTTargetAcceleration) -> GSTTargetAcceleration:
 		accel.set_zero()
 		return accel
 	else:
-		var orientation := atan2(agent.linear_velocity.x, -agent.linear_velocity.y)
+		var orientation := GSTUtils.vector_to_angle(agent.linear_velocity)
 		return _match_orientation(accel, orientation)

--- a/project/src/Behaviors/GSTMatchOrientation.gd
+++ b/project/src/Behaviors/GSTMatchOrientation.gd
@@ -4,12 +4,17 @@ extends GSTSteeringBehavior
 # The calculation will attempt to arrive with zero remaining angular velocity.
 
 
+# The target orientation for the behavior to try and match rotations to
 var target: GSTAgentLocation
+# The amount of distance in radians for the behavior to consider itself close enough to match
 var alignment_tolerance: float
+# The amount of distance in radians from the goal to start slowing down
 var deceleration_radius: float
+# A constant to represent the time it takes to change angular accelerations
 var time_to_reach: float = 0.1
 
 
+# Initializes the behavior
 func _init(agent: GSTSteeringAgent, target: GSTAgentLocation).(agent) -> void:
 	self.target = target
 

--- a/project/src/Behaviors/GSTPriority.gd
+++ b/project/src/Behaviors/GSTPriority.gd
@@ -1,23 +1,28 @@
 class_name GSTPriority
 extends GSTSteeringBehavior
-# Contains multiple steering behaviors and returns only the result of the first that has a non-zero
- # acceleration.
+# Contains multiple behaviors and returns only the result of the first with non-zero acceleration.
 
 
 var _behaviors := []
 
+# The index in the behavior array of the last behavior that was selected.
 var last_selected_index: int
+# The amount of acceleration for a behavior to be considered to have effectively zero acceleration
 var zero_threshold: float
 
 
+# Initializes the behavior
 func _init(agent: GSTSteeringAgent, zero_threshold := 0.001).(agent) -> void:
 	self.zero_threshold = zero_threshold
 
 
+# Add a steering `behavior` to the pool of behaviors to consider
 func add(behavior: GSTSteeringBehavior) -> void:
 	_behaviors.append(behavior)
 
 
+# Returns the behavior at the position in the pool referred to by `index`.
+# Returns `null` if none were found.
 func get_behavior_at(index: int) -> GSTSteeringBehavior:
 	if _behaviors.size() > index:
 		return _behaviors[index]

--- a/project/src/Behaviors/GSTPursue.gd
+++ b/project/src/Behaviors/GSTPursue.gd
@@ -1,14 +1,16 @@
 class_name GSTPursue
 extends GSTSteeringBehavior
-# Calculates acceleration to take an agent to intersect with where a target agent will be.
+# Calculates acceleration to take an agent to intersect with where a target agent will be, instead
+# of where it currently is.
 
-# # The `predict_time_max` variable represents how far ahead to calculate the intersection point.
 
-
+# The target agent that the behavior is trying to intercept
 var target: GSTSteeringAgent
+# The maximum amount of time in the future for the behavior to predict the target's position
 var predict_time_max: float
 
 
+# Initializes the behavior
 func _init(
 		agent: GSTSteeringAgent,
 		target: GSTSteeringAgent,

--- a/project/src/Behaviors/GSTSeek.gd
+++ b/project/src/Behaviors/GSTSeek.gd
@@ -1,11 +1,13 @@
 class_name GSTSeek
 extends GSTSteeringBehavior
-# Calculates acceleration to take an agent to a target agent's position as directly as possible
+# Calculates acceleration to take an agent to a target agent's position directly
 
 
+# The target that the behavior aims to move the agent to
 var target: GSTAgentLocation
 
 
+# Initializes the behavior
 func _init(agent: GSTSteeringAgent, target: GSTAgentLocation).(agent) -> void:
 	self.target = target
 

--- a/project/src/Behaviors/GSTSeparation.gd
+++ b/project/src/Behaviors/GSTSeparation.gd
@@ -1,18 +1,19 @@
 class_name GSTSeparation
 extends GSTGroupBehavior
-# Group behavior that produces acceleration repelling from the other neighbors that are in the
-# immediate area defined by the given `GSTProximity`.
+# Group behavior that produces acceleration that repels the agent from the other neighbors that
+# are in the area defined by the given `GSTProximity`.
+# 
+# The produced acceleration is an average of all agents under consideration, multiplied by a
+# strength decreasing by the inverse square law in relation to distance, and accumulated.
 
-# # The produced acceleration is an average of all agents under consideration, multiplied by a
-# # strength decreasing by the inverse square law in relation to distance, and accumulated.
-# # In effect, all neighbors produce a single repelling force.
 
-
+# The constant coefficient to calculate how fast the separation strength decays with distance.
 var decay_coefficient := 1.0
 
 var acceleration: GSTTargetAcceleration
 
 
+# Initializes the behavior
 func _init(agent: GSTSteeringAgent, proximity: GSTProximity).(agent, proximity) -> void:
 	pass
 

--- a/project/src/GSTAgentLocation.gd
+++ b/project/src/GSTAgentLocation.gd
@@ -1,6 +1,8 @@
 class_name GSTAgentLocation
-# Data type to represent an agent with a location and an orientation
+# Data type to represent an agent with a location and an orientation only.
 
 
+# The agent's position in space.
 var position := Vector3.ZERO
+# The agent's orientation on its Y axis rotation.
 var orientation := 0.0

--- a/project/src/GSTGroupBehavior.gd
+++ b/project/src/GSTGroupBehavior.gd
@@ -9,7 +9,7 @@ var proximity: GSTProximity
 var _callback := funcref(self, "report_neighbor")
 
 
-# Initializes the behavior with its owning `agent` and group's `proximity`
+# Initializes the behavior
 func _init(agent: GSTSteeringAgent, proximity: GSTProximity).(agent) -> void:
 	self.proximity = proximity
 

--- a/project/src/GSTGroupBehavior.gd
+++ b/project/src/GSTGroupBehavior.gd
@@ -3,14 +3,17 @@ class_name GSTGroupBehavior
 # Extended behavior that features a Proximity group for group-based behaviors.
 
 
+# The group area definition that will be used to find the owning agent's neighbors
 var proximity: GSTProximity
 
 var _callback := funcref(self, "report_neighbor")
 
 
+# Initializes the behavior with its owning `agent` and group's `proximity`
 func _init(agent: GSTSteeringAgent, proximity: GSTProximity).(agent) -> void:
 	self.proximity = proximity
 
 
+# Internal callback for the behavior to define whether or not a member is relevant
 func report_neighbor(neighbor: GSTSteeringAgent) -> bool:
 	return false

--- a/project/src/GSTPath.gd
+++ b/project/src/GSTPath.gd
@@ -1,12 +1,12 @@
 extends Reference
 class_name GSTPath
 # Represents a path made up of Vector3 waypoints, split into path segments for use by path
-# following algorithms.
-
-# # Keeping it updated requires calling `create_path` to update the path.
+# following behaviors.
 
 
+# Whether the path is a loop, or has its start and end disconnected and open ended
 var open: bool
+# The length of the full path
 var length: float
 
 var _segments: Array
@@ -15,6 +15,7 @@ var _nearest_point_on_segment: Vector3
 var _nearest_point_on_path: Vector3
 
 
+# Initializes and creates a path with the provided waypoints
 func _init(waypoints: Array, open := false) -> void:
 	self.open = open
 	create_path(waypoints)
@@ -22,6 +23,7 @@ func _init(waypoints: Array, open := false) -> void:
 	_nearest_point_on_path = waypoints[0]
 
 
+# Creates a path with the provided waypoints
 func create_path(waypoints: Array) -> void:
 	if not waypoints or waypoints.size() < 2:
 		printerr("Waypoints cannot be null and must contain at least two (2) waypoints.")
@@ -46,7 +48,8 @@ func create_path(waypoints: Array) -> void:
 		_segments.append(segment)
 
 
-func calculate_distance(agent_current_position: Vector3, path_parameter: Dictionary) -> float:
+# Returns the distance from the provided `agent_current_position` to the next point waypoint.
+func calculate_distance(agent_current_position: Vector3) -> float:
 	if _segments.size() == 0:
 		return 0.0
 	var smallest_distance_squared: float = INF
@@ -63,18 +66,17 @@ func calculate_distance(agent_current_position: Vector3, path_parameter: Diction
 			_nearest_point_on_path = _nearest_point_on_segment
 			smallest_distance_squared = distance_squared
 			nearest_segment = segment
-			path_parameter.segment_index = i
 	
 	var length_on_path := (
 		nearest_segment.cumulative_length - 
 		_nearest_point_on_path.distance_to(nearest_segment.end))
 	
-	path_parameter.distance = length_on_path
-	
 	return length_on_path
 
 
-func calculate_target_position(param: Dictionary, target_distance: float) -> Vector3:
+# Calculates the target position on the path based on the provided `target_distance` from the
+# path's starting point.
+func calculate_target_position(target_distance: float) -> Vector3:
 	if open:
 		target_distance = clamp(target_distance, 0, length)
 	else:
@@ -100,10 +102,12 @@ func calculate_target_position(param: Dictionary, target_distance: float) -> Vec
 		(distance / desired_segment.length) + desired_segment.end)
 
 
+# Returns the position of the beginning point of the path
 func get_start_point() -> Vector3:
 	return _segments.front().begin
 
 
+# Returns the position of the last point of the path
 func get_end_point() -> Vector3:
 	return _segments.back().end
 

--- a/project/src/GSTSteeringAgent.gd
+++ b/project/src/GSTSteeringAgent.gd
@@ -1,14 +1,24 @@
 extends GSTAgentLocation
 class_name GSTSteeringAgent
-# Extended agent data type that adds velocity, speed, and size data
+# An extended `GSTAgentLocation` that adds velocity, speed, and size data. It is the character's
+# responsibility to keep this information up to date for the steering toolkit to work correctly.
 
 
+# The amount of velocity to be considered effectively not moving.
 var zero_linear_speed_threshold := 0.01
+# The maximum amount of speed the agent can move at.
 var linear_speed_max := 0.0
+# The maximum amount of acceleration that any behavior can apply to an agent.
 var linear_acceleration_max := 0.0
+# The maximum amount of angular speed the agent can rotate at.
 var angular_speed_max := 0.0
+# The maximum amount of angular acceleration that any behavior can apply to an agent.
 var angular_acceleration_max := 0.0
+# The current speed in a given direction the agent is traveling at.
 var linear_velocity := Vector3.ZERO
+# The current angular speed the agent is traveling at.
 var angular_velocity := 0.0
+# The radius of the sphere that approximates the agent's size in space.
 var bounding_radius := 0.0
+# Used internally by group behaviors and proximities to mark an agent as already considered.
 var tagged := false

--- a/project/src/GSTSteeringBehavior.gd
+++ b/project/src/GSTSteeringBehavior.gd
@@ -1,15 +1,21 @@
 class_name GSTSteeringBehavior
-# Base class to calculate how an AI agent steers itself.
+# The base class for all steering behaviors to extend. A steering behavior calculates the linear
+# and/or angular acceleration to be applied to its owning agent
 
 
+# Whether this behavior is enabled. All disabled behaviors return zero amounts of acceleration.
+# Defaults to true
 var enabled := true
+# The agent on which all steering calculations are to be made.
 var agent: GSTSteeringAgent
 
 
+# Sets the behavior's owning `agent`
 func _init(agent: GSTSteeringAgent) -> void:
 	self.agent = agent
 
 
+# Returns the `acceleration` parameter modified with the behavior's desired amount of acceleration
 func calculate_steering(acceleration: GSTTargetAcceleration) -> GSTTargetAcceleration:
 	if enabled:
 		return _calculate_steering(acceleration)

--- a/project/src/GSTSteeringBehavior.gd
+++ b/project/src/GSTSteeringBehavior.gd
@@ -1,6 +1,9 @@
 class_name GSTSteeringBehavior
 # The base class for all steering behaviors to extend. A steering behavior calculates the linear
 # and/or angular acceleration to be applied to its owning agent
+# 
+# The entry point for all behaviors is the `calculate_steering` function. Everything else is
+# self-contained within the behavior.
 
 
 # Whether this behavior is enabled. All disabled behaviors return zero amounts of acceleration.
@@ -10,7 +13,7 @@ var enabled := true
 var agent: GSTSteeringAgent
 
 
-# Sets the behavior's owning `agent`
+# Initializes the behavior
 func _init(agent: GSTSteeringAgent) -> void:
 	self.agent = agent
 

--- a/project/src/GSTTargetAcceleration.gd
+++ b/project/src/GSTTargetAcceleration.gd
@@ -1,11 +1,14 @@
 class_name GSTTargetAcceleration
-# A linear and angular amount of acceleration.
+# A desired linear and angular amount of acceleration requested by the steering system.
 
 
+# The linear amount of acceleration
 var linear := Vector3.ZERO
+# The angular amount of acceleration
 var angular := 0.0
 
 
+# Sets the linear and angular components to 0
 func set_zero() -> void:
 	linear.x = 0.0
 	linear.y = 0.0
@@ -13,14 +16,17 @@ func set_zero() -> void:
 	angular = 0.0
 
 
+# Adds `accel`'s components, multiplied by `scalar`, to this one.
 func add_scaled_accel(accel: GSTTargetAcceleration, scalar: float) -> void:
 	linear += accel.linear * scalar
 	angular += accel.angular * scalar
 
 
+# Returns the squared magnitude of the linear and angular components
 func get_magnitude_squared() -> float:
 	return linear.length_squared() + angular * angular
 
 
+# Returns the magnitude of the linear and angular components
 func get_magnitude() -> float:
 	return sqrt(get_magnitude_squared())

--- a/project/src/GSTUtils.gd
+++ b/project/src/GSTUtils.gd
@@ -1,10 +1,17 @@
 class_name GSTUtils
-# Useful math and utility functions to complement Godot's own.
+# Useful math and vector manipulation functions to complement Godot's own.
 
 
+# Returns the provided `vector` with its length capped to `limit`.
 static func clampedv3(vector: Vector3, limit: float) -> Vector3:
 	var length_squared := vector.length_squared()
 	var limit_squared := limit * limit
 	if length_squared > limit_squared:
 		vector *= sqrt(limit_squared / length_squared)
 	return vector
+
+
+# Returns the provided vector as an angle in radians. This assumes orientation for 2D
+# agents or 3D agents that are upright and rotate around the Y axis.
+static func vector_to_angle(vector: Vector3) -> float:
+	return atan2(vector.x, -vector.y)


### PR DESCRIPTION
To fix #8 using Nathan's tool as described in #10 

This will add documentation strings, and a python tool will be used to generate and merge into a JSON datadump from which a markup manual can be created.